### PR TITLE
Speed up serial port detection in OSX, excluding bluetooth ports

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/arduino/Serial.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/arduino/Serial.java
@@ -72,7 +72,7 @@ public class Serial implements SerialPortEventListener {
 	    String[] portNames;
 		String OS = System.getProperty("os.name").toLowerCase();
 		if (OS.indexOf("mac") >= 0) {
-			portNames = SerialPortList.getPortNames("/dev/", Pattern.compile("tty.*"));
+			portNames = SerialPortList.getPortNames("/dev/", Pattern.compile("^cu\\..*(serial|usb).*"));
 		}
 		else {
 			portNames = SerialPortList.getPortNames();


### PR DESCRIPTION
Optimized regexp to filter only serial and usbserial ports, excluding bluetooth ports that could slow down the detection process.