### PR TITLE
#409: Fixed inconsistent path separator in get/setPrivateLibraryPaths.

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
@@ -330,7 +330,7 @@ public class InstancePreferences extends Const {
     }
 
     public static void setPrivateLibraryPaths(String[] folderName) {
-	setGlobalValue(KEY_PRIVATE_LIBRARY_PATHS, String.join("\n", folderName)); //$NON-NLS-1$
+	setGlobalValue(KEY_PRIVATE_LIBRARY_PATHS, String.join(File.pathSeparator, folderName)); //$NON-NLS-1$
     }
 
     public static String[] getPrivateHardwarePaths() {


### PR DESCRIPTION
setPrivateLibraryPaths method used "\n" for joining folder names, while
the getter uses File.pathSeparator for splitting. I harmonised to the latter.
Multi private library functionality is working now on (my) Mac too.