### PR TITLE
multiple code improvements: squid:S00117, squid:S1149, squid:S1197, squid:S1854, squid:CommentedOutCodeLine, squid:S1488, squid:S1213, squid:SwitchLastCaseIsDefaultCheck

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Common.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Common.java
@@ -2,6 +2,8 @@ package it.baeyens.arduino.common;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 
 import org.eclipse.cdt.core.CCorePlugin;
@@ -37,16 +39,18 @@ public class Common extends InstancePreferences {
 					       // request him to disconnect
 					       // when we need the serial port
 
+    static Set<IProject> fProjects = new HashSet<>();
+
     /**
      * This method is used to register a serial user. A serial user is alerted
      * when the serial port will be disconnected (for instance for a upload) The
      * serial user is requested to act appropriately Only 1 serial user can be
      * registered at a given time. No check is done.
      * 
-     * @param SerialUser
+     * @param serialUser
      */
-    public static void registerSerialUser(ISerialUser SerialUser) {
-	OtherSerialUser = SerialUser;
+    public static void registerSerialUser(ISerialUser serialUser) {
+	OtherSerialUser = serialUser;
     }
 
     /**
@@ -85,14 +89,14 @@ public class Common extends InstancePreferences {
      * redirect input, allowed in Unix filenames, see Note 1 > greater than used
      * to redirect output, allowed in Unix filenames, see Note 1 . period or dot
      * 
-     * @param Name
+     * @param name
      *            the string that needs to be checked
      * @return a name safe to create files or folders
      */
-    public static String MakeNameCompileSafe(String Name) {
-	char badChars[] = { ' ', '/', '.', '/', ':', ' ', '\\', '(', ')', '*', '?', '%', '|', '<', '>', ',', '-' };
+    public static String MakeNameCompileSafe(String name) {
+	char[] badChars = { ' ', '/', '.', '/', ':', ' ', '\\', '(', ')', '*', '?', '%', '|', '<', '>', ',', '-' };
 
-	String ret = Name.trim();
+	String ret = name.trim();
 	for (char curchar : badChars) {
 	    ret = ret.replace(curchar, '_');
 	}
@@ -105,16 +109,16 @@ public class Common extends InstancePreferences {
      * @param project
      *            The project for which the property is needed
      * 
-     * @param Tag
+     * @param tag
      *            The tag identifying the property to read
      * @return returns the property when found. When not found returns an empty
      *         string
      */
-    public static String getPersistentProperty(IProject project, String Tag) {
+    public static String getPersistentProperty(IProject project, String tag) {
 	try {
-	    String sret = project.getPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, Tag));
+	    String sret = project.getPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, tag));
 	    if (sret == null) {
-		sret = project.getPersistentProperty(new QualifiedName(EMPTY_STRING, Tag)); // for
+		sret = project.getPersistentProperty(new QualifiedName(EMPTY_STRING, tag)); // for
 		// downwards
 		// compatibility
 		if (sret == null)
@@ -122,22 +126,20 @@ public class Common extends InstancePreferences {
 	    }
 	    return sret;
 	} catch (CoreException e) {
-	    log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "Failed to read persistent setting " + Tag, e)); //$NON-NLS-1$
-	    // e.printStackTrace();
+	    log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "Failed to read persistent setting " + tag, e)); //$NON-NLS-1$
 	    return EMPTY_STRING;
 	}
     }
 
-    public static int getPersistentPropertyInt(IProject project, String Tag, int defaultValue) {
+    public static int getPersistentPropertyInt(IProject project, String tag, int defaultValue) {
 	try {
-	    String sret = project.getPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, Tag));
+	    String sret = project.getPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, tag));
 	    if (sret == null) {
 		return defaultValue;
 	    }
 	    return Integer.parseInt(sret);
 	} catch (CoreException e) {
-	    log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "Failed to read persistent setting " + Tag, e)); //$NON-NLS-1$
-	    // e.printStackTrace();
+	    log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "Failed to read persistent setting " + tag, e)); //$NON-NLS-1$
 	    return defaultValue;
 	}
     }
@@ -148,15 +150,15 @@ public class Common extends InstancePreferences {
      * @param project
      *            The project for which the property needs to be set
      * 
-     * @param Tag
+     * @param tag
      *            The tag identifying the property to read
      * @return returns the property when found. When not found returns an empty
      *         string
      */
-    public static void setPersistentProperty(IProject project, String Tag, String Value) {
+    public static void setPersistentProperty(IProject project, String tag, String value) {
 	try {
-	    project.setPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, Tag), Value);
-	    project.setPersistentProperty(new QualifiedName(EMPTY_STRING, Tag), Value); // for
+	    project.setPersistentProperty(new QualifiedName(CORE_PLUGIN_ID, tag), value);
+	    project.setPersistentProperty(new QualifiedName(EMPTY_STRING, tag), value); // for
 	    // downwards
 	    // compatibility
 	} catch (CoreException e) {
@@ -166,8 +168,8 @@ public class Common extends InstancePreferences {
 	}
     }
 
-    public static void setPersistentProperty(IProject project, String Tag, int Value) {
-	setPersistentProperty(project, Tag, Integer.toString(Value));
+    public static void setPersistentProperty(IProject project, String tag, int value) {
+	setPersistentProperty(project, tag, Integer.toString(value));
     }
 
     /**
@@ -177,7 +179,7 @@ public class Common extends InstancePreferences {
      *            the status information to log
      */
     public static void log(IStatus status) {
-	int style = StatusManager.LOG;
+	int style;
 
 	if (status.getSeverity() == IStatus.ERROR) {
 	    style = StatusManager.LOG | StatusManager.SHOW | StatusManager.BLOCK;
@@ -209,7 +211,7 @@ public class Common extends InstancePreferences {
     /**
      * ToInt converts a string to a integer in a save way
      * 
-     * @param Number
+     * @param number
      *            is a String that will be converted to an integer. Number can
      *            be null or empty and can contain leading and trailing white
      *            space
@@ -217,12 +219,12 @@ public class Common extends InstancePreferences {
      * @see parseInt. After error checking and modifications parseInt is used
      *      for the conversion
      **/
-    public static int ToInt(String Number) {
-	if (Number == null)
+    public static int ToInt(String number) {
+	if (number == null)
 	    return 0;
-	if (Number.isEmpty())
+	if (number.isEmpty())
 	    return 0;
-	return Integer.parseInt(Number.trim());
+	return Integer.parseInt(number.trim());
     }
 
     public static IWorkbenchWindow getActiveWorkbenchWindow() {
@@ -236,8 +238,6 @@ public class Common extends InstancePreferences {
 	}
 	return null;
     }
-
-    static HashSet<IProject> fProjects = new HashSet<>();
 
     public static boolean StopSerialMonitor(String mComPort) {
 	if (OtherSerialUser != null) {
@@ -254,9 +254,9 @@ public class Common extends InstancePreferences {
     }
 
     public static String[] listComPorts() {
-	Vector<String> SerialList = Serial.list();
-	String outgoing[] = new String[SerialList.size()];
-	SerialList.copyInto(outgoing);
+	List<String> serialList = Serial.list();
+	String[] outgoing = new String[serialList.size()];
+	serialList.toArray(outgoing);
 	return outgoing;
     }
 
@@ -294,16 +294,16 @@ public class Common extends InstancePreferences {
      *            the project that contains the environment variable
      * @param configName
      *            the project configuration to use
-     * @param EnvName
+     * @param envName
      *            the key that describes the variable
      * @param defaultvalue
      *            The return value if the variable is not found.
      * @return The expanded build environment variable
      */
-    static public String getBuildEnvironmentVariable(IProject project, String configName, String EnvName,
+    static public String getBuildEnvironmentVariable(IProject project, String configName, String envName,
 	    String defaultvalue) {
 	ICProjectDescription prjDesc = CoreModel.getDefault().getProjectDescription(project);
-	return getBuildEnvironmentVariable(prjDesc.getConfigurationByName(configName), EnvName, defaultvalue);
+	return getBuildEnvironmentVariable(prjDesc.getConfigurationByName(configName), envName, defaultvalue);
     }
 
     /**
@@ -314,15 +314,15 @@ public class Common extends InstancePreferences {
      * @param project
      *            the project that contains the environment variable
      * 
-     * @param EnvName
+     * @param envName
      *            the key that describes the variable
      * @param defaultvalue
      *            The return value if the variable is not found.
      * @return The expanded build environment variable
      */
-    static public String getBuildEnvironmentVariable(IProject project, String EnvName, String defaultvalue) {
+    static public String getBuildEnvironmentVariable(IProject project, String envName, String defaultvalue) {
 	ICProjectDescription prjDesc = CoreModel.getDefault().getProjectDescription(project);
-	return getBuildEnvironmentVariable(prjDesc.getDefaultSettingConfiguration(), EnvName, defaultvalue);
+	return getBuildEnvironmentVariable(prjDesc.getDefaultSettingConfiguration(), envName, defaultvalue);
     }
 
     /**
@@ -332,24 +332,24 @@ public class Common extends InstancePreferences {
      * 
      * @param project
      *            the project that contains the environment variable
-     * @param EnvName
+     * @param envName
      *            the key that describes the variable
      * @param defaultvalue
      *            The return value if the variable is not found.
      * @return The expanded build environment variable
      */
     static public String getBuildEnvironmentVariable(ICConfigurationDescription configurationDescription,
-	    String EnvName, String defaultvalue) {
+	    String envName, String defaultvalue) {
 
-	return getBuildEnvironmentVariable(configurationDescription, EnvName, defaultvalue, true);
+	return getBuildEnvironmentVariable(configurationDescription, envName, defaultvalue, true);
     }
 
     static public String getBuildEnvironmentVariable(ICConfigurationDescription configurationDescription,
-	    String EnvName, String defaultvalue, boolean expanded) {
+	    String envName, String defaultvalue, boolean expanded) {
 
 	IEnvironmentVariableManager envManager = CCorePlugin.getDefault().getBuildEnvironmentManager();
 	try {
-	    return envManager.getVariable(EnvName, configurationDescription, expanded).getValue();
+	    return envManager.getVariable(envName, configurationDescription, expanded).getValue();
 	} catch (Exception e) {// ignore all errors and return the default value
 	}
 	return defaultvalue;
@@ -374,8 +374,7 @@ public class Common extends InstancePreferences {
 
     public static File getWorkspaceRoot() {
 	IWorkspaceRoot myWorkspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
-	File ret = myWorkspaceRoot.getLocation().toFile();
-	return ret;
+	return myWorkspaceRoot.getLocation().toFile();
     }
 
     public static void setBuildEnvironmentVariable(IContributedEnvironment contribEnv,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1854 - Dead stores should be removed.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava