### PR TITLE
multiple code improvements: squid:S1118, squid:S1197, squid:UselessParenthesesCheck, squid:CommentedOutCodeLine, squid:S2864

### DIFF
--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/managers/ArduinoPlatform.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/managers/ArduinoPlatform.java
@@ -145,12 +145,12 @@ public class ArduinoPlatform {
 	    this.platformProperties = new Properties();
 	    try (BufferedReader reader = new BufferedReader(new FileReader(getPlatformFile()))) {
 		// There are regex's here and need to preserve the \'s
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 		for (String line = reader.readLine(); line != null; line = reader.readLine()) {
-		    buffer.append(line.replace("\\", "\\\\")); //$NON-NLS-1$ //$NON-NLS-2$
-		    buffer.append('\n');
+		    builder.append(line.replace("\\", "\\\\")); //$NON-NLS-1$ //$NON-NLS-2$
+		    builder.append('\n');
 		}
-		try (Reader reader1 = new StringReader(buffer.toString())) {
+		try (Reader reader1 = new StringReader(builder.toString())) {
 		    this.platformProperties.load(reader1);
 		}
 	    } catch (IOException e) {

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/managers/Manager.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/managers/Manager.java
@@ -64,6 +64,8 @@ public class Manager {
 	static private List<PackageIndex> packageIndices;
 	static private LibraryIndex libraryIndex;
 
+	private Manager() {}
+
 	private static void internalLoadIndices() {
 		String[] boardUrls = ConfigurationPreferences.getBoardURLList();
 		packageIndices = new ArrayList<>(boardUrls.length);
@@ -100,7 +102,7 @@ public class Manager {
 				if (pkg != null) {
 					ArduinoPlatform platform = pkg.getLatestPlatform(platformName);
 					if (platform == null) {
-						ArduinoPlatform platformList[] = new ArduinoPlatform[pkg.getLatestPlatforms().size()];
+						ArduinoPlatform[] platformList = new ArduinoPlatform[pkg.getLatestPlatforms().size()];
 						pkg.getLatestPlatforms().toArray(platformList);
 						platform = platformList[0];
 					}
@@ -169,7 +171,6 @@ public class Manager {
 			}
 		}
 
-		// mstatus.add(make_eclipse_plugin_txt_file(platform));
 		return mstatus.getChildren().length == 0 ? Status.OK_STATUS : mstatus;
 
 	}
@@ -327,8 +328,8 @@ public class Manager {
 		return platforms;
 	}
 
-	public static ArduinoPlatform getPlatform(String PlatformTxt) {
-		String searchString = new File(PlatformTxt).toString();
+	public static ArduinoPlatform getPlatform(String platformTxt) {
+		String searchString = new File(platformTxt).toString();
 		for (PackageIndex index : packageIndices) {
 			for (Package pkg : index.getPackages()) {
 				for (ArduinoPlatform curPlatform : pkg.getPlatforms()) {
@@ -627,8 +628,8 @@ public class Manager {
 		}
 
 		// Set folders timestamps
-		for (File folder : foldersTimestamps.keySet()) {
-			folder.setLastModified(foldersTimestamps.get(folder).longValue());
+		for (Map.Entry<File, Long> entry : foldersTimestamps.entrySet()) {
+			entry.getKey().setLastModified(entry.getValue().longValue());
 		}
 
 		return Status.OK_STATUS;
@@ -672,7 +673,7 @@ public class Manager {
 
 			// if size is not available, copy until EOF...
 			if (size == -1) {
-				byte buffer[] = new byte[4096];
+				byte[] buffer = new byte[4096];
 				int length;
 				while ((length = in.read(buffer)) != -1) {
 					fos.write(buffer, 0, length);
@@ -681,7 +682,7 @@ public class Manager {
 			}
 
 			// ...else copy just the needed amount of bytes
-			byte buffer[] = new byte[4096];
+			byte[] buffer = new byte[4096];
 			long leftToWrite = size;
 			while (leftToWrite > 0) {
 				int length = in.read(buffer);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
George Kankava