### PR TITLE
Fix for preference page not saving some preferences

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Defaults.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Defaults.java
@@ -1,0 +1,6 @@
+package it.baeyens.arduino.common;
+
+public class Defaults {
+	public static final boolean OPEN_SERIAL_WITH_MONITOR = true;
+	public static final boolean AUTO_IMPORT_LIBRARIES = true;
+}

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/InstancePreferences.java
@@ -26,7 +26,7 @@ import org.osgi.service.prefs.BackingStoreException;
 public class InstancePreferences extends Const {
 
     public static boolean getOpenSerialWithMonitor() {
-	return getGlobalBoolean(KEY_OPEN_SERIAL_WITH_MONITOR, true);
+	return getGlobalBoolean(KEY_OPEN_SERIAL_WITH_MONITOR, Defaults.OPEN_SERIAL_WITH_MONITOR);
     }
 
     public static void setOpenSerialWithMonitor(boolean value) {
@@ -39,7 +39,7 @@ public class InstancePreferences extends Const {
      * @return true if libraries need to be added else false.
      */
     public static boolean getAutomaticallyIncludeLibraries() {
-	return getGlobalBoolean(KEY_AUTO_IMPORT_LIBRARIES, true);
+	return getGlobalBoolean(KEY_AUTO_IMPORT_LIBRARIES, Defaults.AUTO_IMPORT_LIBRARIES);
     }
 
     public static void setAutomaticallyIncludeLibraries(boolean value) {

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/PreferencePage.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/PreferencePage.java
@@ -15,6 +15,7 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 
 import it.baeyens.arduino.common.Const;
+import it.baeyens.arduino.common.Defaults;
 
 /**
  * ArduinoPreferencePage is the class that is behind the preference page of
@@ -38,7 +39,11 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
     public PreferencePage() {
 	super(org.eclipse.jface.preference.FieldEditorPreferencePage.GRID);
 	setDescription(Messages.ui_workspace_settings);
-	setPreferenceStore(new ScopedPreferenceStore(InstanceScope.INSTANCE, Const.NODE_ARDUINO));
+	
+	ScopedPreferenceStore preferences = new ScopedPreferenceStore(InstanceScope.INSTANCE, Const.NODE_ARDUINO);
+	preferences.setDefault(Const.KEY_OPEN_SERIAL_WITH_MONITOR, Defaults.OPEN_SERIAL_WITH_MONITOR);
+	preferences.setDefault(Const.KEY_AUTO_IMPORT_LIBRARIES, Defaults.AUTO_IMPORT_LIBRARIES);
+	setPreferenceStore(preferences);
     }
 
     @Override

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/PreferencePage.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/PreferencePage.java
@@ -95,12 +95,10 @@ public class PreferencePage extends FieldEditorPreferencePage implements IWorkbe
 	this.arduinoPrivateLibPath = new PathEditor(Const.KEY_PRIVATE_LIBRARY_PATHS, Messages.ui_private_lib_path,
 		Messages.ui_private_lib_path_help, parent);
 	addField(this.arduinoPrivateLibPath);
-	this.arduinoPrivateLibPath.setPreferenceStore(getPreferenceStore());
 
 	this.arduinoPrivateHardwarePath = new PathEditor(Const.KEY_PRIVATE_HARDWARE_PATHS,
 		Messages.ui_private_hardware_path, Messages.ui_private_hardware_path_help, parent);
 	addField(this.arduinoPrivateHardwarePath);
-	this.arduinoPrivateHardwarePath.setPreferenceStore(getPreferenceStore());
 
 	Dialog.applyDialogFont(parent);
 	createLine(parent, 4);


### PR DESCRIPTION
see https://github.com/jantje/arduino-eclipse-plugin/issues/408

Eclipse checked boolean preference value against 'default' value and just removed the preference from store if new value was equal to default value (false for boolean values by default).

This commit overrides default values for boolean preferences, making them the same in default preference initializer and in preference page editor. 