### PR TITLE
606: Remove dependency on org.eclipse.wb.core.lib

### DIFF
--- a/io.sloeber.product/arduino.product
+++ b/io.sloeber.product/arduino.product
@@ -320,7 +320,6 @@ rights to a jury trial in any resulting litigation.&lt;/p&gt;
       <feature id="org.eclipse.equinox.p2.rcp.feature" installMode="root"/>
       <feature id="org.eclipse.equinox.p2.user.ui" installMode="root"/>
       <feature id="org.eclipse.help" installMode="root"/>
-      <feature id="org.eclipse.jdt" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.commons" installMode="root"/>
@@ -340,7 +339,6 @@ rights to a jury trial in any resulting litigation.&lt;/p&gt;
       <feature id="org.eclipse.rse" installMode="root"/>
       <feature id="org.eclipse.cdt.testsrunner.feature"/>
       <feature id="org.eclipse.equinox.core.sdk"/>
-      <feature id="org.eclipse.pde"/>
       <feature id="org.eclipse.rse.local"/>
       <feature id="org.eclipse.mylyn.tasks.ide"/>
       <feature id="org.eclipse.rse.dstore"/>

--- a/io.sloeber.product/config/mac/config.ini
+++ b/io.sloeber.product/config/mac/config.ini
@@ -1,0 +1,14 @@
+#This configuration file was written by: org.eclipse.equinox.internal.frameworkadmin.equinox.EquinoxFwConfigFileParser
+#Wed Dec 07 17:24:49 CET 2016
+eclipse.p2.profile=DefaultProfile
+osgi.framework=file\:plugins/org.eclipse.osgi_3.11.1.v20160708-1632.jar
+equinox.use.ds=true
+osgi.bundles=reference\:file\:org.eclipse.equinox.simpleconfigurator_1.1.200.v20160504-1450.jar@1\:start
+org.eclipse.equinox.simpleconfigurator.configUrl=file\:org.eclipse.equinox.simpleconfigurator/bundles.info
+eclipse.product=io.sloeber.application.product
+osgi.splashPath=platform\:/base/plugins/io.sloeber.application
+osgi.framework.extensions=reference\:file\:org.eclipse.equinox.region_1.3.1.v20160816-1331.jar,reference\:file\:org.eclipse.equinox.transforms.hook_1.1.0.v20131021-1933.jar,reference\:file\:org.eclipse.equinox.weaving.hook_1.1.200.v20150730-1648.jar,reference\:file\:org.eclipse.osgi.compatibility.state_1.0.200.v20160504-1419.jar
+osgi.bundles.defaultStartLevel=4
+eclipse.p2.data.area=@config.dir/../p2
+eclipse.application=org.eclipse.ui.ide.workbench
+osgi.instance.area.default=@user.home/Documents/sloeber-workspace

--- a/io.sloeber.product/neon-cdt-nebula.target
+++ b/io.sloeber.product/neon-cdt-nebula.target
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="neon-cdt-nebula" sequenceNumber="13">
+<locations>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.test.feature.group" version="3.7.100.v20160503-1715"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.nebula.feature.feature.group" version="1.1.0.201612071713"/>
+<repository location="http://download.eclipse.org/nebula/snapshot"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.ecf.core.feature.group" version="3.13.2.v20160823-2221"/>
+<unit id="org.eclipse.mylyn.ide_feature.feature.group" version="3.20.0.v20160421-1902"/>
+<unit id="org.eclipse.epp.mpc.feature.group" version="1.5.2.v20161005-1414"/>
+<unit id="org.eclipse.cdt.testsrunner.feature.feature.group" version="9.1.0.201609121658"/>
+<unit id="org.eclipse.egit.mylyn.feature.group" version="4.4.1.201607150455-r"/>
+<unit id="org.eclipse.mylyn.wikitext_feature.feature.group" version="2.9.0.v20160601-1831"/>
+<unit id="org.eclipse.mylyn.bugzilla_feature.feature.group" version="3.20.0.v20160425-1835"/>
+<unit id="org.eclipse.equinox.sdk.feature.group" version="3.12.0.v20160829-1338"/>
+<unit id="org.eclipse.mylyn.git.feature.group" version="1.12.0.v20160421-1824"/>
+<unit id="org.eclipse.cdt.mylyn.feature.group" version="5.16.0.v20160421-1902"/>
+<unit id="org.eclipse.mylyn_feature.feature.group" version="3.20.0.v20160608-1838"/>
+<unit id="org.eclipse.egit.gitflow.feature.feature.group" version="4.4.1.201607150455-r"/>
+<unit id="org.eclipse.emf.sdk.feature.group" version="2.12.0.v20160526-0356"/>
+<unit id="org.eclipse.cdt.autotools.feature.group" version="9.1.0.201609121658"/>
+<unit id="org.eclipse.mylyn.context_feature.feature.group" version="3.20.0.v20160608-1905"/>
+<unit id="org.eclipse.rse.useractions.feature.group" version="3.7.0.201603211627"/>
+<unit id="org.eclipse.rse.feature.group" version="3.7.1.201603211627"/>
+<unit id="org.eclipse.egit.feature.group" version="4.4.1.201607150455-r"/>
+<unit id="org.eclipse.cdt.feature.group" version="9.1.0.201609121658"/>
+<repository location="http://download.eclipse.org/releases/neon"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="javax.xml.stream" version="1.0.1.v201004272200"/>
+<unit id="org.apache.commons.lang" version="2.6.0.v201404270220"/>
+<unit id="org.apache.commons.io.source" version="2.2.0.v201405211200"/>
+<unit id="org.apache.commons.io" version="2.2.0.v201405211200"/>
+<unit id="org.apache.commons.lang.source" version="2.6.0.v201404270220"/>
+<unit id="javax.xml.bind" version="2.2.0.v201105210648"/>
+<repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository/"/>
+</location>
+<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.platform.sdk" version="4.6.1.M20160907-1200"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6"/>
+</location>
+</locations>
+</target>


### PR DESCRIPTION
Also remove PDE and JDT dependency, create a target file and change config.ini to put the default workspace in path ~/Documents/sloeber-worksapce as default instead of the invisible and non-selectable application root folder. This must also be best practice on Linux and Windows with multiple users: each user gets his own workspace.